### PR TITLE
Add cross-database copy utilities

### DIFF
--- a/es-es.js
+++ b/es-es.js
@@ -1,0 +1,44 @@
+const elasticsearch = require("elasticsearch");
+
+const source_host = "localhost:9200";
+const source_version = "7.6";
+const source_index = "es_index";
+
+const target_host = "localhost:9200";
+const target_version = "7.6";
+const target_index = "es_index";
+
+const sourceClient = new elasticsearch.Client({
+  host: source_host,
+  apiVersion: source_version,
+});
+
+const targetClient = new elasticsearch.Client({
+  host: target_host,
+  apiVersion: target_version,
+});
+
+const dump = async () => {
+  let res = await sourceClient.search({
+    index: source_index,
+    scroll: "1m",
+    body: { query: { match_all: {} } },
+    size: 1000,
+  });
+
+  while (true) {
+    const hits = res.hits.hits;
+    if (!hits.length) break;
+    let bulk = [];
+    for (const hit of hits) {
+      bulk.push({ index: { _index: target_index, _id: hit._id } });
+      bulk.push(hit._source);
+    }
+    await targetClient.bulk({ body: bulk });
+    res = await sourceClient.scroll({ scrollId: res._scroll_id, scroll: "1m" });
+  }
+};
+
+(async () => {
+  await dump();
+})();

--- a/es-mongo.js
+++ b/es-mongo.js
@@ -1,0 +1,55 @@
+const elasticsearch = require("elasticsearch");
+const MongoClient = require("mongodb").MongoClient;
+
+const es_index = "es_index";
+const es_host = "localhost:9200";
+const es_version = "7.6";
+
+const mongo_host = "mongodb://localhost:27017";
+const mongo_dbname = "db_name";
+const mongo_collection = "collection";
+
+const esClient = new elasticsearch.Client({
+  host: es_host,
+  apiVersion: es_version,
+});
+
+const connMongo = async () => {
+  const client = await MongoClient.connect(mongo_host, { useUnifiedTopology: true });
+  return [client, client.db(mongo_dbname)];
+};
+
+const dump = async (targetCollection) => {
+  let res = await esClient.search({
+    index: es_index,
+    scroll: "1m",
+    body: { query: { match_all: {} } },
+    size: 1000,
+  });
+
+  while (true) {
+    const hits = res.hits.hits;
+    if (!hits.length) break;
+    for (const hit of hits) {
+      const doc = hit._source;
+      doc._id = hit._id;
+      try {
+        await targetCollection.insertOne(doc);
+      } catch (e) {
+        console.log(e.message);
+      }
+    }
+    res = await esClient.scroll({ scrollId: res._scroll_id, scroll: "1m" });
+  }
+};
+
+const main = async () => {
+  const [client, db] = await connMongo();
+  const collection = db.collection(mongo_collection);
+  await dump(collection);
+  client.close();
+};
+
+(async () => {
+  await main();
+})();

--- a/es-mysql.js
+++ b/es-mysql.js
@@ -1,0 +1,61 @@
+const elasticsearch = require("elasticsearch");
+const mariadb = require("mariadb");
+
+const es_index = "es_index";
+const es_host = "localhost:9200";
+const es_version = "7.6";
+
+const mysql_config = {
+  host: "127.0.0.1",
+  user: "user",
+  password: "xxx",
+  port: "3306",
+  database: "db_name",
+};
+const mysql_table = "table";
+
+const esClient = new elasticsearch.Client({
+  host: es_host,
+  apiVersion: es_version,
+});
+
+const connMysql = async () => {
+  const pool = mariadb.createPool(mysql_config);
+  return await pool.getConnection();
+};
+
+const dump = async (target) => {
+  let res = await esClient.search({
+    index: es_index,
+    scroll: "1m",
+    body: { query: { match_all: {} } },
+    size: 1000,
+  });
+
+  while (true) {
+    const hits = res.hits.hits;
+    if (!hits.length) break;
+    for (const hit of hits) {
+      const doc = hit._source;
+      const fields = Object.keys(doc);
+      const values = fields.map((f) => doc[f]);
+      await target.query(
+        `INSERT IGNORE ${mysql_table} (${fields.join(",")}) VALUE (${fields
+          .map(() => "?")
+          .join(",")})`,
+        values
+      );
+    }
+    res = await esClient.scroll({ scrollId: res._scroll_id, scroll: "1m" });
+  }
+};
+
+const main = async () => {
+  const mysql = await connMysql();
+  await dump(mysql);
+  mysql.end();
+};
+
+(async () => {
+  await main();
+})();

--- a/mongo-mysql.js
+++ b/mongo-mysql.js
@@ -1,0 +1,55 @@
+const MongoClient = require("mongodb").MongoClient;
+const mariadb = require("mariadb");
+
+const mongo_host = "mongodb://localhost:27017";
+const mongo_dbname = "db_name";
+const mongo_collection = "collection";
+
+const mysql_config = {
+  host: "127.0.0.1",
+  user: "user",
+  password: "xxx",
+  port: "3306",
+  database: "db_name",
+};
+const mysql_table = "table";
+
+const connMongo = async () => {
+  const client = await MongoClient.connect(mongo_host, { useUnifiedTopology: true });
+  return [client, client.db(mongo_dbname)];
+};
+
+const connMysql = async () => {
+  const pool = mariadb.createPool(mysql_config);
+  return await pool.getConnection();
+};
+
+const dump = async (sourceCollection, target) => {
+  const cursor = sourceCollection.find({}).batchSize(1000);
+  let doc;
+  while ((doc = await cursor.next())) {
+    const fields = Object.keys(doc);
+    const values = fields.map((f) => (f === "_id" ? String(doc[f]) : doc[f]));
+    await target.query(
+      `INSERT IGNORE ${mysql_table} (${fields.join(",")}) VALUE (${fields
+        .map(() => "?")
+        .join(",")})`,
+      values
+    );
+  }
+};
+
+const main = async () => {
+  const [mongoClient, mongo] = await connMongo();
+  const target = await connMysql();
+  const collection = mongo.collection(mongo_collection);
+
+  await dump(collection, target);
+
+  target.end();
+  mongoClient.close();
+};
+
+(async () => {
+  await main();
+})();

--- a/mysql-es.js
+++ b/mysql-es.js
@@ -1,0 +1,57 @@
+const mariadb = require("mariadb");
+const elasticsearch = require("elasticsearch");
+
+const mysql_config = {
+  host: "127.0.0.1",
+  user: "user",
+  password: "xxx",
+  port: "3306",
+  database: "db_name",
+};
+const mysql_table = "table";
+
+const es_index = "es_index";
+const es_host = "localhost:9200";
+const es_version = "7.6";
+
+const limit = 300;
+const start_row = 0;
+const limit_break = 500000;
+
+const esClient = new elasticsearch.Client({
+  host: es_host,
+  apiVersion: es_version,
+});
+
+const connMysql = async () => {
+  const pool = mariadb.createPool(mysql_config);
+  return await pool.getConnection();
+};
+
+const dump = async (source, offset) => {
+  const rows = await source.query(`SELECT * FROM ${mysql_table} order by id desc limit ${limit} offset ${offset}`);
+  let bulk = [];
+  for (const row of rows) {
+    bulk.push({ index: { _index: es_index, _id: row.id } });
+    bulk.push(row);
+  }
+  if (bulk.length > 0) {
+    await esClient.bulk({ body: bulk });
+  }
+  return rows.length === limit;
+};
+
+const main = async () => {
+  const source = await connMysql();
+  let offset = start_row;
+  let more;
+  do {
+    more = await dump(source, offset);
+    offset += limit;
+  } while (offset < limit_break && more);
+  source.end();
+};
+
+(async () => {
+  await main();
+})();

--- a/mysql-mongo.js
+++ b/mysql-mongo.js
@@ -1,0 +1,57 @@
+const mariadb = require("mariadb");
+const MongoClient = require("mongodb").MongoClient;
+
+const mysql_config = {
+  host: "127.0.0.1",
+  user: "user",
+  password: "xxx",
+  port: "3306",
+  database: "db_name",
+};
+const mysql_table = "table";
+
+const mongo_host = "mongodb://localhost:27017";
+const mongo_dbname = "db_name";
+const mongo_collection = "collection";
+
+const limit = 300;
+const start_row = 0;
+const limit_break = 500000;
+
+const connMysql = async () => {
+  const pool = mariadb.createPool(mysql_config);
+  return await pool.getConnection();
+};
+
+const connMongo = async () => {
+  const client = await MongoClient.connect(mongo_host, { useUnifiedTopology: true });
+  return [client, client.db(mongo_dbname)];
+};
+
+const dump = async (source, targetCollection, offset) => {
+  const rows = await source.query(`SELECT * FROM ${mysql_table} order by id desc limit ${limit} offset ${offset}`);
+  for (const row of rows) {
+    await targetCollection.insertOne(row);
+  }
+  return rows.length === limit;
+};
+
+const main = async () => {
+  const source = await connMysql();
+  const [mongoClient, mongo] = await connMongo();
+  const collection = mongo.collection(mongo_collection);
+
+  let offset = start_row;
+  let more;
+  do {
+    more = await dump(source, collection, offset);
+    offset += limit;
+  } while (offset < limit_break && more);
+
+  source.end();
+  mongoClient.close();
+};
+
+(async () => {
+  await main();
+})();

--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,33 @@
 - copy row by row (bulk)
 
 ```node mongo-es.js```
+
+### copy mongo to mysql
+- copy row by row (bulk)
+
+```node mongo-mysql.js```
+
+### copy mysql to mongo
+- copy row by row (bulk)
+
+```node mysql-mongo.js```
+
+### copy mysql to es
+- copy row by row (bulk)
+
+```node mysql-es.js```
+
+### copy es to mongo
+- copy row by row (bulk)
+
+```node es-mongo.js```
+
+### copy es to mysql
+- copy row by row (bulk)
+
+```node es-mysql.js```
+
+### copy es to es
+- copy row by row (bulk)
+
+```node es-es.js```


### PR DESCRIPTION
## Summary
- add scripts to copy between all DB combinations
- document how to run each script in readme

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68402a618684832aacac42d712e2aab2